### PR TITLE
Nomes de referências de classe e propriedades sendo usados com diretiva nameof()

### DIFF
--- a/Source/Maverick.Domain/Exceptions/BuscarFilmesCoreException.cs
+++ b/Source/Maverick.Domain/Exceptions/BuscarFilmesCoreException.cs
@@ -19,13 +19,13 @@ namespace Maverick.Domain.Exceptions
         {
         }
 
-        public override string Key => "BuscarFilmesCoreException";
+        public override string Key => nameof(BuscarFilmesCoreException);
     }
 
     public class BuscarFilmesCoreError : CoreError
     {
         public static BuscarFilmesCoreError LimiteDeRequisicoesAtingido =>
-            new BuscarFilmesCoreError("LimiteDeRequisicoesAtingido", 
+            new BuscarFilmesCoreError(nameof(LimiteDeRequisicoesAtingido), 
                 "O limite de requisições ao provedor de filmes foi atingido, " +
                 "tente novamente mais tarde.");
         


### PR DESCRIPTION
Utilizando nameof() ao invés de string hardcode para evitar possibilidade de erros do desenvolvedor que acarretem falhas de execução e facilitar possíveis refactors