### PR TITLE
Simply updating template version to make Nuget notice past fixes

### DIFF
--- a/Template/Maverick.nuspec
+++ b/Template/Maverick.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Maverick</id>
-        <version>3.1.2</version>
+        <version>3.1.3</version>
 	<description>DDD/WebAPI project template.</description>
         <authors>Ole Consignado</authors>
         <packageTypes>


### PR DESCRIPTION
Last template fixes weren't effective due to lack of Nuget package version update.